### PR TITLE
Add instance folder to git

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,7 +62,6 @@ db.sqlite3
 db.sqlite3-journal
 
 # Flask stuff:
-instance/
 .webassets-cache
 
 # Scrapy stuff:


### PR DESCRIPTION
This adds the instance folder to git. Ignores most of the contents but doesn't ignore the .gitkeep, which is necessary for the folder to be uploaded to git.